### PR TITLE
fix: workflow_dispatch経由でClaude Code Actionを直接実行

### DIFF
--- a/.github/workflows/discussion-claude-answer.yml
+++ b/.github/workflows/discussion-claude-answer.yml
@@ -1,0 +1,100 @@
+name: Discussion Claude Answer
+
+on:
+  workflow_dispatch:
+    inputs:
+      question:
+        description: "ユーザーからの質問"
+        required: true
+        type: string
+      discussion_number:
+        description: "Discussion番号"
+        required: true
+        type: string
+      comment_url:
+        description: "元のコメントURL"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  discussions: write
+  id-token: write
+
+jobs:
+  claude-answer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Login GitHub App
+        id: login-gh-app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.KIBA_CLAUDE_CODE_GH_APP_ID }}
+          private-key: ${{ secrets.KIBA_CLAUDE_CODE_GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Answer with Claude Code
+        uses: anthropics/claude-code-action@v1
+        env:
+          GITHUB_TOKEN: ${{ steps.login-gh-app.outputs.token }}
+        with:
+          github_token: ${{ steps.login-gh-app.outputs.token }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          settings: |
+            {
+              "permissions": {
+                "allow": ["Bash(deno task reply-discussion *)", "Read", "Write", "WebFetch", "WebSearch"]
+              }
+            }
+          allowed_bots: "github-actions[bot]"
+          prompt: |
+            Discussion #${{ inputs.discussion_number }} から以下の質問を受けました：
+
+            > ${{ inputs.question }}
+
+            ${{ inputs.comment_url && format('元のコメント: {0}', inputs.comment_url) || '' }}
+
+            この質問について、このリポジトリのコンテキストを踏まえて回答してください。
+
+            ## リポジトリについて
+            - このリポジトリは技術系Changelogを自動収集・要約・投稿するシステムです
+            - データは data/changelogs/ に保存されています
+            - GitHub Changelog、AWS What's New、Claude Codeの情報を収集します
+            - Claude Code Actionで要約を生成してGitHub Discussionsに投稿します
+
+            ## 利用可能なデータ
+            - data/changelogs/ ディレクトリ内のJSONファイルを読み込んで参考にできます
+            - 最新のチェンジログデータを確認して回答に活用してください
+
+            ## 回答タスク
+            1. 質問に対する明確な回答を提供
+            2. 必要に応じてリポジトリ内のデータを参照・分析
+            3. 技術的な内容は日本語でわかりやすく説明
+            4. 回答を一時ファイルに保存
+            5. 以下のコマンドを実行してDiscussionに投稿：
+
+            ```bash
+            # 回答を一時ファイルに保存
+            cat > claude_answer.md << 'EOF'
+            [ここにあなたの回答を記載]
+
+            ---
+            *この回答は Claude Code Action によって生成されました*
+            [ワークフロー実行ログ](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            EOF
+
+            # Discussionにコメントを投稿
+            deno task reply-discussion ${{ inputs.discussion_number }} "$(cat claude_answer.md)"
+            ```
+
+            必ず最後のコマンドを実行して回答を投稿してください。

--- a/.github/workflows/discussion-claude-mention.yml
+++ b/.github/workflows/discussion-claude-mention.yml
@@ -1,98 +1,39 @@
-name: Discussion Claude Mention
+name: Discussion Claude Mention Trigger
 
 on:
   discussion_comment:
     types: [created]
 
 permissions:
-  contents: read
-  id-token: write
+  actions: write
 
 jobs:
-  claude-mention:
+  trigger-claude:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '@claude') && github.event.comment.user.login == 'korosuke613'
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
       - name: Parse mention content
         id: parse-mention
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           # @claude メンション後のテキストを抽出
-          question=$(echo "$COMMENT_BODY" | sed -n 's/.*@claude[[:space:]]*\(.*\)/\1/p' | head -1)
+          question=$(echo "$COMMENT_BODY" | sed -n 's/.*@claude[[:space:]]*\(.*\)/\1/p')
           if [ -z "$question" ]; then
-            echo "question=@claude メンションが見つかりましたが、質問が空です。" >> $GITHUB_OUTPUT
+            echo "question=質問内容が空です" >> $GITHUB_OUTPUT
           else
+            # 複数行対応とエスケープ処理
+            question=$(echo "$question" | tr '\n' ' ')
             echo "question=$question" >> $GITHUB_OUTPUT
           fi
 
-      - name: Login GitHub App
-        id: login-gh-app
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.KIBA_CLAUDE_CODE_GH_APP_ID }}
-          private-key: ${{ secrets.KIBA_CLAUDE_CODE_GH_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
-      - name: Answer with Claude Code
-        uses: anthropics/claude-code-action@v1
+      - name: Trigger Claude Code workflow
         env:
-          GITHUB_TOKEN: ${{ steps.login-gh-app.outputs.token }}
-        with:
-          github_token: ${{ steps.login-gh-app.outputs.token }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          settings: |
-            {
-              "permissions": {
-                "allow": ["Bash(deno task reply-discussion *)", "Read", "Write"]
-              }
-            }
-          prompt: |
-            ユーザーから以下の質問を受けました：
-            「${{ steps.parse-mention.outputs.question }}」
-
-            この質問について、このリポジトリのコンテキストを踏まえて回答してください。
-
-            ## リポジトリについて
-            - このリポジトリは技術系Changelogを自動収集・要約・投稿するシステムです
-            - データは data/changelogs/ に保存されています
-            - GitHub Changelog、AWS What's New、Claude Codeの情報を収集します
-            - Claude Code Actionで要約を生成してGitHub Discussionsに投稿します
-
-            ## 利用可能なデータ
-            - data/changelogs/ ディレクトリ内のJSONファイルを読み込んで参考にできます
-            - 最新のチェンジログデータを確認して回答に活用してください
-
-            ## 回答フォーマット
-            1. 質問に対する明確な回答を提供
-            2. 必要に応じてリポジトリ内のデータを参照・分析
-            3. 技術的な内容は日本語でわかりやすく説明
-            4. 最後に以下のコマンドを実行して回答をDiscussionに投稿：
-
-            ```bash
-            # 回答を一時ファイルに保存
-            cat > claude_answer.md << 'EOF'
-            # Claude からの回答
-
-            [ここに生成した回答を記載]
-
-            ---
-            *この回答は Claude Code Action によって生成されました*
-            [ワークフロー実行ログ](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            EOF
-
-            # GitHub CLI を使ってDiscussionにコメントを投稿
-            deno task reply-discussion ${{ github.event.discussion.number }} "$(cat claude_answer.md)"
-            ```
-
-            必ず最後のコマンドを実行して回答を投稿してください。
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run discussion-claude-answer.yml \
+            --repo ${{ github.repository }} \
+            --field question="${{ steps.parse-mention.outputs.question }}" \
+            --field discussion_number="${{ github.event.discussion.number }}" \
+            --field comment_url="${{ github.event.comment.html_url }}"

--- a/plans/2026-01-19-discussion-claude-mention.md
+++ b/plans/2026-01-19-discussion-claude-mention.md
@@ -4,23 +4,46 @@
 
 GitHub Discussionsで `@claude` メンションを使ってClaude Code Actionに質問できる機能を実装しました。
 
+## 実装アプローチ
+
+Claude Code Actionは`discussion_comment`イベントを直接サポートしていないため、以下の2段階アプローチを採用：
+
+1. **トリガーワークフロー** (`discussion-claude-mention.yml`): `discussion_comment`イベントで起動し、質問内容を解析して別ワークフローをトリガー
+2. **実行ワークフロー** (`discussion-claude-answer.yml`): `workflow_dispatch`で起動し、Claude Code Actionを直接実行してDiscussionに回答を投稿
+
 ## 実装内容
 
-### 1. GitHub Actions ワークフロー (.github/workflows/discussion-claude-mention.yml)
+### 1. トリガーワークフロー (.github/workflows/discussion-claude-mention.yml)
 
-- **トリガー**: `discussion_comment` (created) - Discussion内でコメントが作成された時
-- **条件**: コメント内に `@claude` メンションが含まれている場合のみ実行
+- **トリガー**: `discussion_comment` (created) 
+- **条件**: コメント内に `@claude` メンションが含まれ、ユーザーが `korosuke613` の場合のみ実行
+- **権限**: actions:write
+
+**処理フロー**:
+1. `@claude` メンション後の質問文を抽出
+2. `gh workflow run` で実行ワークフローをトリガー
+3. 質問内容、Discussion番号、コメントURLを引数として渡す
+
+### 2. 実行ワークフロー (.github/workflows/discussion-claude-answer.yml)
+
+- **トリガー**: `workflow_dispatch` (手動実行可能)
+- **入力パラメータ**: 
+  - `question`: ユーザーからの質問
+  - `discussion_number`: Discussion番号
+  - `comment_url`: 元のコメントURL
 - **権限**: contents:read, discussions:write, id-token:write
 
-**主な処理フロー**:
+**処理フロー**:
 1. リポジトリをチェックアウト
-2. Deno環境をセットアップ  
-3. `@claude` メンション後の質問文を抽出
-4. GitHub Appでログイン
-5. Claude Code Actionに質問を送信し、回答を生成
-6. 生成した回答をDiscussionに投稿
+2. Deno環境をセットアップ
+3. GitHub Appでログイン
+4. Claude Code Actionを直接実行
+   - 質問内容をプロンプトとして渡す
+   - リポジトリのコンテキスト（Changelogシステムの仕様）を提供
+   - Claudeが回答を生成
+   - `deno task reply-discussion` でDiscussionに回答を投稿
 
-### 2. Discussion回答投稿スクリプト (scripts/reply-discussion.ts)
+### 3. Discussion回答投稿スクリプト (scripts/reply-discussion.ts)
 
 GitHub GraphQL APIを使用してDiscussionにコメントを投稿する機能：
 
@@ -38,48 +61,56 @@ deno task reply-discussion <discussion-number> "<comment-body>"
 deno task reply-discussion <discussion-number> <owner> <repo> "<comment-body>"
 ```
 
-### 3. Denoタスク設定の更新 (deno.json)
+### 4. Denoタスク設定の更新 (deno.json)
 
 `reply-discussion` タスクを追加：
 ```json
 "reply-discussion": "deno run --allow-net --allow-env scripts/reply-discussion.ts"
 ```
 
-## Claude Code Actionでの処理
+## データフロー
 
-Claude Code Actionは以下の流れで質問に回答します：
-
-1. **質問の解釈**: ユーザーから受け取った質問を理解
-2. **コンテキスト把握**: リポジトリの情報（Changelogシステムの仕様）を考慮
-3. **データ参照**: 必要に応じて `data/changelogs/` 内のJSONファイルを読み込み
-4. **回答生成**: 質問に対する詳細な回答を日本語で生成
-5. **投稿処理**: 回答をMarkdown形式でDiscussionに投稿
+```
+Discussion Comment (@claude mention)
+  ↓
+discussion-claude-mention.yml (trigger)
+  ↓ (gh workflow run with question/discussion_number)
+discussion-claude-answer.yml (workflow_dispatch)
+  ↓ (直接実行)
+Claude Code Action
+  ↓ (deno task reply-discussion)
+Discussion Comment (answer)
+```
 
 ## 使用方法
 
 1. 対象のDiscussion（例: https://github.com/korosuke613/mynewshq/discussions/9）を開く
 2. コメント欄に `@claude` メンションと質問を入力
 3. 例: `@claude 最新のAWS変更点について詳しく教えて`
-4. Claudeが自動的に回答をコメントで投稿
+4. トリガーワークフローが自動起動し、実行ワークフローを呼び出す
+5. Claude Code Actionが質問を処理し、回答を生成
+6. 回答が自動的にDiscussionにコメントとして投稿される
 
 ## セキュリティ考慮事項
 
 - GitHub Appトークンを使用した認証
-- 適切な権限設定（discussions:write等）
+- 適切な権限設定（discussions:write、actions:write等）
 - 環境変数での機密情報管理
 - Claude Code OAuth Tokenの安全な管理
+- korosuke613 ユーザーからのメンションのみ処理
 
 ## 今後の拡張可能性
 
-- メンション形式の改善（複数行質問対応等）
-- 回答にコンテキスト情報の自動添付
-- 特定のトピック（AWS、GitHub等）での専門的な回答
-- Discussion内の過去の会話履歴を考慮した回答
+- 回答生成状況の通知機能（進行中であることを通知）
+- 複数ユーザー対応（allowlistの追加）
+- エラー時のリトライ機能
+- Discussion内での会話履歴の考慮
 
-## 注意点
+## 制約事項
 
+- Claude Code Actionは`discussion_comment`イベントを直接サポートしていない（`workflow_dispatch`経由で回避）
+- `workflow_dispatch`のトリガーには若干の遅延が発生する可能性がある
 - Claude Code Actionの実行制限に注意
-- GitHub API rate limitへの配慮
-- 大量のメンションスパム対策（必要に応じて実装）
+- GitHub API rate limitへの配慮が必要
 
 この実装により、Discussionでの対話的な技術サポートが可能になります。


### PR DESCRIPTION
- Issueを中継せずworkflow_dispatchでClaude Code Actionを呼び出し
- トリガーワークフローでdiscussion_commentを検知
- 実行ワークフローでClaude Code Actionが質問に回答しDiscussionに投稿
- 不要なIssue作成・クローズ処理を削除
- korosuke613ユーザーのメンションのみ処理