### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -1,5 +1,8 @@
 name: Quality Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/korosuke613/mynewshq/security/code-scanning/1](https://github.com/korosuke613/mynewshq/security/code-scanning/1)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in this workflow to the minimum required. Since all steps just check out the code and run Deno linting, type checking, formatting, and tests, they only need read access to repository contents.

The best fix is to add a `permissions` block at the workflow root (top-level, next to `name` and `on`) so it applies to all jobs, including `quality`. Set `contents: read`, which allows checking out and reading the repository but prevents writes. This will not change existing behavior for these steps, because none of them attempt to write to GitHub resources.

Concretely, in `.github/workflows/quality-check.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `name: Quality Check` line (line 1) and before the `on:` block (line 3). No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
