### PR TITLE
fix: Discussion回答機能のBash許可設定と引数チェックを修正

### DIFF
--- a/.github/workflows/discussion-claude-answer.yml
+++ b/.github/workflows/discussion-claude-answer.yml
@@ -53,7 +53,7 @@ jobs:
           settings: |
             {
               "permissions": {
-                "allow": ["Bash(deno task reply-discussion *)", "Read", "Write", "WebFetch", "WebSearch"]
+                "allow": ["Bash(deno task reply-discussion *)", "Bash(cat *)", "Read", "Write", "WebFetch", "WebSearch"]
               }
             }
           allowed_bots: "github-actions[bot]"

--- a/scripts/reply-discussion.ts
+++ b/scripts/reply-discussion.ts
@@ -98,9 +98,9 @@ async function replyToDiscussion(
 async function main(): Promise<void> {
   const args = Deno.args;
 
-  if (args.length < 3) {
+  if (args.length !== 2 && args.length !== 4) {
     console.error(
-      "Usage: deno run reply-discussion.ts <discussion-number> <owner> <repo> [body]",
+      "Usage: deno run reply-discussion.ts <discussion-number> <owner> <repo> <body>",
     );
     console.error(
       "  or: deno run reply-discussion.ts <discussion-number> <body> (uses GITHUB_REPOSITORY)",


### PR DESCRIPTION
- ワークフローのBash許可設定に Bash(cat *) を追加
  - cat > file によるファイル作成を許可
- reply-discussion.tsの引数チェックを修正
  - args.length < 3 を args.length !== 2 && args.length !== 4 に変更
  - 2引数パターン（GITHUB_REPOSITORY使用）を正しく受け入れるように