### PR TITLE
fix: Discussion回答を元コメントへのリプライとして投稿

### DIFF
--- a/.github/workflows/discussion-claude-answer.yml
+++ b/.github/workflows/discussion-claude-answer.yml
@@ -11,6 +11,10 @@ on:
         description: "Discussion番号"
         required: true
         type: string
+      comment_id:
+        description: "リプライ先のコメントノードID"
+        required: false
+        type: string
       comment_url:
         description: "元のコメントURL"
         required: false
@@ -113,4 +117,9 @@ jobs:
             echo "Error: Extracted 'answer' field is empty or null"
             exit 1
           fi
-          deno task reply-discussion ${{ inputs.discussion_number }} "$BODY"
+          COMMENT_ID="${{ inputs.comment_id }}"
+          if [ -n "$COMMENT_ID" ]; then
+            deno task reply-discussion ${{ inputs.discussion_number }} "$BODY" "$COMMENT_ID"
+          else
+            deno task reply-discussion ${{ inputs.discussion_number }} "$BODY"
+          fi

--- a/.github/workflows/discussion-claude-mention.yml
+++ b/.github/workflows/discussion-claude-mention.yml
@@ -39,4 +39,5 @@ jobs:
             --repo ${{ github.repository }} \
             --field question="$QUESTION" \
             --field discussion_number="${{ github.event.discussion.number }}" \
+            --field comment_id="${{ github.event.comment.node_id }}" \
             --field comment_url="${{ github.event.comment.html_url }}"


### PR DESCRIPTION
@claudeメンションへの回答がトップレベルコメントではなく、
元のコメントへのリプライスレッドとして投稿されるように修正。

- comment_node_idをワークフロー間で受け渡し
- reply-discussion.tsでreplyToIdパラメータをサポート
- addDiscussionComment mutationにreplyToIdを渡す