### PR TITLE
fix: PR#71 レビュー指摘のフォローアップ対応

### DIFF
--- a/.github/workflows/weekly-changelog.yml
+++ b/.github/workflows/weekly-changelog.yml
@@ -285,6 +285,7 @@ jobs:
           echo "{" > /tmp/all-summaries.json
           FIRST=true
 
+          # NOTE: このリストは scripts/domain/weekly/types.ts の WEEKLY_PROVIDER_IDS と同期が必要
           for provider in github aws claudeCode linear; do
             FILE="/tmp/summaries/${provider}.json"
             if [ -f "$FILE" ]; then

--- a/scripts/domain/weekly/orchestrator.ts
+++ b/scripts/domain/weekly/orchestrator.ts
@@ -62,6 +62,15 @@ export function getProviderDataFromChangelog(
 }
 
 /**
+ * mutedエントリを除外するユーティリティ関数
+ */
+export function filterMutedEntries<T extends Array<{ muted?: boolean }>>(
+  data: T,
+): T {
+  return data.filter((entry) => !entry.muted) as T;
+}
+
+/**
  * Weekly Orchestrator
  * 全プロバイダーの週次処理を統括
  */
@@ -118,8 +127,8 @@ export class WeeklyOrchestrator {
     for (const [providerId, adapter] of this.adapters.entries()) {
       const currentData = this.getProviderData(changelogData, providerId);
 
-      // mutedエントリを除外（型を保持するためにプロバイダーごとに処理）
-      const filteredData = this.filterMutedEntries(currentData, providerId);
+      // mutedエントリを除外
+      const filteredData = filterMutedEntries(currentData);
 
       // データがない場合はスキップ
       if (filteredData.length === 0) {
@@ -200,19 +209,6 @@ export class WeeklyOrchestrator {
     providerId: string,
   ): ChangelogEntry[] | ReleaseEntry[] {
     return getProviderDataFromChangelog(changelogData, providerId);
-  }
-
-  /**
-   * mutedエントリを除外（型を保持）
-   */
-  private filterMutedEntries(
-    data: ChangelogEntry[] | ReleaseEntry[],
-    _providerId: string,
-  ): ChangelogEntry[] | ReleaseEntry[] {
-    // プロバイダーに依存せず muted フラグのみでフィルタリング
-    return (data as Array<ChangelogEntry | ReleaseEntry>).filter(
-      (entry) => !entry.muted,
-    ) as ChangelogEntry[] | ReleaseEntry[];
   }
 
   /**

--- a/scripts/weekly-orchestrator.ts
+++ b/scripts/weekly-orchestrator.ts
@@ -5,6 +5,7 @@ import type { ChangelogData, ProviderWeeklySummary } from "./domain/types.ts";
 import type { WeeklyContext } from "./domain/weekly/types.ts";
 import {
   createOrchestrator,
+  filterMutedEntries,
   getAdapter,
   getProviderDataFromChangelog,
 } from "./domain/weekly/orchestrator.ts";
@@ -264,12 +265,7 @@ async function renderPrompt(options: {
   );
 
   // mutedエントリを除外
-  const filteredData = currentData.filter((entry) => {
-    if (typeof entry === "object" && entry !== null && "muted" in entry) {
-      return !(entry as { muted?: boolean }).muted;
-    }
-    return true;
-  });
+  const filteredData = filterMutedEntries(currentData);
 
   // プロンプトを生成
   const config = adapter.getSummarizeConfig();


### PR DESCRIPTION
## Summary
- PR #71 のマージ後に追加されたレビュー指摘への対応
- `filterMutedEntries` をユーティリティ関数として公開し、重複コードを削除
- 未使用パラメータの削除
- ワークフローにプロバイダーリスト同期の注意書きを追加

## 対応したレビューコメント
| コメント | 対応 |
|----------|------|
| mutedフィルタリングの重複 | ✅ ユーティリティ関数で統一 |
| `_providerId`パラメータ未使用 | ✅ 削除 |
| プロバイダーリストのハードコード | ✅ 同期が必要な旨のコメント追加 |

## 対応しなかったコメント
| コメント | 理由 |
|----------|------|
| コマンドバリデーション | main関数のswitch文のdefaultでhelp表示されるため実用上問題なし |
| ランダム色生成のテスタビリティ | ラベル色は視覚的な区別のみで、テストに影響しない |

## Test plan
- [x] `deno task test` - 全94テストパス
- [x] `deno check` - 型チェックパス
- [x] `deno lint` - リントパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)