### PR TITLE
fix: 週次ラベルを日次形式（具体的サービス名）に統一

### DIFF
--- a/plans/2026-01-28-weekly-label-unification.md
+++ b/plans/2026-01-28-weekly-label-unification.md
@@ -1,0 +1,77 @@
+# 週次ラベルを日次形式（具体的サービス名）に統一
+
+## 概要
+
+日次と週次でDiscussionのラベル形式が異なる問題を修正し、週次でも日次と同じ具体的サービス名ラベル（`aws:deadline-cloud`など）を使用するように統一する。
+
+## 現状の問題
+
+| 種類 | ラベル例 | 生成元 |
+|------|----------|--------|
+| 日次 | `aws:deadline-cloud`, `aws:rds` | 元データの `labels` フィールド |
+| 週次 | `aws:AI/ML (Bedrock/SageMaker)` | Claude生成のカテゴリ名 |
+
+**原因**: `categorized-adapter.ts` の `buildSingleProviderChangelogData()` で、Claude生成のカテゴリ名を `labels` として設定している（L77, L118）
+
+## 実装計画
+
+### 1. `WeeklyPipeline` インターフェース変更
+**ファイル**: `scripts/domain/weekly/pipeline.ts`
+
+`postDiscussion` メソッドに `providerData` パラメータを追加（必須パラメータ）:
+```typescript
+postDiscussion(
+  markdown: string,
+  summary: ProviderWeeklySummary,
+  ctx: WeeklyContext,
+  providerData: ChangelogEntry[] | ReleaseEntry[], // 追加（必須）
+): Promise<PipelineResult<PostDiscussionData>>;
+```
+
+### 2. `BaseAdapter` の変更
+**ファイル**: `scripts/domain/weekly/adapters/base-adapter.ts`
+
+- `postDiscussion`: `providerData` パラメータを受け取り、`addLabels` に渡す
+- `addLabels`: `summary` ではなく `providerData` を使用してラベル抽出
+- 新規メソッド `buildChangelogDataFromProviderData`: 元データから `ChangelogData` を構築
+
+### 3. サブクラスの整理
+**ファイル**:
+- `scripts/domain/weekly/adapters/categorized-adapter.ts`
+- `scripts/domain/weekly/adapters/simple-adapter.ts`
+
+`buildSingleProviderChangelogData` メソッドを削除（不要になるため）
+
+### 4. `WeeklyOrchestrator` の変更
+**ファイル**: `scripts/domain/weekly/orchestrator.ts`
+
+`postAllDiscussions` で `postDiscussion` 呼び出し時に元データ（`providerData`）を渡す
+
+## 修正対象ファイル
+
+1. `scripts/domain/weekly/pipeline.ts` - インターフェース変更
+2. `scripts/domain/weekly/adapters/base-adapter.ts` - 主要な変更
+3. `scripts/domain/weekly/adapters/categorized-adapter.ts` - メソッド削除
+4. `scripts/domain/weekly/adapters/simple-adapter.ts` - メソッド削除
+5. `scripts/domain/weekly/orchestrator.ts` - 呼び出し変更
+
+## 検証方法
+
+```bash
+# 型チェック
+deno check scripts/*.ts scripts/**/*.ts
+
+# テスト実行
+deno task test
+
+# 週次プレビューでラベル確認
+deno task preview-weekly-provider -- --provider=aws
+```
+
+## 注意点
+
+- カテゴリ分類は週次レポート本文に残る（ラベルのみ変更）
+- ミュートエントリも含めて全エントリの `labels` を使用（日次と同じ動作）
+
+## TODO
+- [ ] 実装完了後、プランファイルを `plans/2026-01-28-weekly-label-unification.md` にリネーム

--- a/scripts/domain/weekly/adapters/categorized-adapter.ts
+++ b/scripts/domain/weekly/adapters/categorized-adapter.ts
@@ -1,7 +1,11 @@
 // カテゴリ分類ありアダプタ（GitHub/AWS用）
 // labels フィールドを使用してカテゴリ別要約を生成
 
-import type { ChangelogData, ProviderWeeklySummary } from "../../types.ts";
+import type {
+  ChangelogData,
+  ChangelogEntry,
+  ReleaseEntry,
+} from "../../types.ts";
 import type { SummarizeConfig } from "../pipeline.ts";
 import type { WeeklyContext } from "../types.ts";
 import { CATEGORIZED_SUMMARY_SCHEMA } from "../types.ts";
@@ -62,27 +66,15 @@ export class GitHubAdapter extends BaseAdapter {
     };
   }
 
-  protected buildSingleProviderChangelogData(
-    summary: ProviderWeeklySummary,
+  protected buildChangelogDataFromProviderData(
+    providerData: ChangelogEntry[] | ReleaseEntry[],
     ctx: WeeklyContext,
   ): ChangelogData {
-    // summaryからエントリを復元（カテゴリ内のエントリを収集）
-    const entries =
-      summary.categories?.flatMap((cat) =>
-        cat.entries.map((e) => ({
-          title: e.title,
-          url: e.url,
-          content: "",
-          pubDate: ctx.endDate,
-          labels: { "changelog-label": [cat.category] },
-        }))
-      ) ?? [];
-
     return {
       date: ctx.endDate,
       startDate: ctx.startDate,
       endDate: ctx.endDate,
-      github: entries,
+      github: providerData as ChangelogEntry[],
       aws: [],
       claudeCode: [],
       linear: [],
@@ -103,28 +95,16 @@ export class AWSAdapter extends BaseAdapter {
     };
   }
 
-  protected buildSingleProviderChangelogData(
-    summary: ProviderWeeklySummary,
+  protected buildChangelogDataFromProviderData(
+    providerData: ChangelogEntry[] | ReleaseEntry[],
     ctx: WeeklyContext,
   ): ChangelogData {
-    // summaryからエントリを復元（カテゴリ内のエントリを収集）
-    const entries =
-      summary.categories?.flatMap((cat) =>
-        cat.entries.map((e) => ({
-          title: e.title,
-          url: e.url,
-          content: "",
-          pubDate: ctx.endDate,
-          labels: { "changelog-label": [cat.category] },
-        }))
-      ) ?? [];
-
     return {
       date: ctx.endDate,
       startDate: ctx.startDate,
       endDate: ctx.endDate,
       github: [],
-      aws: entries,
+      aws: providerData as ChangelogEntry[],
       claudeCode: [],
       linear: [],
     };

--- a/scripts/domain/weekly/adapters/simple-adapter.ts
+++ b/scripts/domain/weekly/adapters/simple-adapter.ts
@@ -3,7 +3,7 @@
 
 import type {
   ChangelogData,
-  ProviderWeeklySummary,
+  ChangelogEntry,
   ReleaseEntry,
 } from "../../types.ts";
 import type { SummarizeConfig } from "../pipeline.ts";
@@ -70,25 +70,17 @@ export class ClaudeCodeAdapter extends BaseAdapter {
     };
   }
 
-  protected buildSingleProviderChangelogData(
-    summary: ProviderWeeklySummary,
+  protected buildChangelogDataFromProviderData(
+    providerData: ChangelogEntry[] | ReleaseEntry[],
     ctx: WeeklyContext,
   ): ChangelogData {
-    // summaryからReleaseEntryを復元
-    const releases: ReleaseEntry[] = summary.entries?.map((e) => ({
-      version: e.title,
-      url: e.url,
-      body: "",
-      publishedAt: ctx.endDate,
-    })) ?? [];
-
     return {
       date: ctx.endDate,
       startDate: ctx.startDate,
       endDate: ctx.endDate,
       github: [],
       aws: [],
-      claudeCode: releases,
+      claudeCode: providerData as ReleaseEntry[],
       linear: [],
     };
   }
@@ -107,18 +99,10 @@ export class LinearAdapter extends BaseAdapter {
     };
   }
 
-  protected buildSingleProviderChangelogData(
-    summary: ProviderWeeklySummary,
+  protected buildChangelogDataFromProviderData(
+    providerData: ChangelogEntry[] | ReleaseEntry[],
     ctx: WeeklyContext,
   ): ChangelogData {
-    // summaryからChangelogEntryを復元
-    const entries = summary.entries?.map((e) => ({
-      title: e.title,
-      url: e.url,
-      content: "",
-      pubDate: ctx.endDate,
-    })) ?? [];
-
     return {
       date: ctx.endDate,
       startDate: ctx.startDate,
@@ -126,7 +110,7 @@ export class LinearAdapter extends BaseAdapter {
       github: [],
       aws: [],
       claudeCode: [],
-      linear: entries,
+      linear: providerData as ChangelogEntry[],
     };
   }
 }

--- a/scripts/domain/weekly/orchestrator.ts
+++ b/scripts/domain/weekly/orchestrator.ts
@@ -178,7 +178,7 @@ export class WeeklyOrchestrator {
 
         const data = this.getProviderData(changelogData, providerId);
         const markdown = adapter.generateMarkdown(data, summary, ctx);
-        const result = await adapter.postDiscussion(markdown, summary, ctx);
+        const result = await adapter.postDiscussion(markdown, ctx, data);
 
         return [providerId, result] as const;
       }),
@@ -225,7 +225,7 @@ export class WeeklyOrchestrator {
 
     const data = this.getProviderData(changelogData, providerId);
     const markdown = adapter.generateMarkdown(data, summary, ctx);
-    return await adapter.postDiscussion(markdown, summary, ctx);
+    return await adapter.postDiscussion(markdown, ctx, data);
   }
 }
 

--- a/scripts/domain/weekly/pipeline.ts
+++ b/scripts/domain/weekly/pipeline.ts
@@ -53,14 +53,14 @@ export interface WeeklyPipeline {
   /**
    * Discussionを投稿
    * @param markdown 投稿するMarkdown
-   * @param summary 要約データ（タイトル生成等に使用）
    * @param ctx 週次処理コンテキスト
+   * @param providerData 元データ（ラベル抽出に使用）
    * @returns 投稿結果（URL等）のPipelineResult
    */
   postDiscussion(
     markdown: string,
-    summary: ProviderWeeklySummary,
     ctx: WeeklyContext,
+    providerData: ChangelogEntry[] | ReleaseEntry[],
   ): Promise<PipelineResult<PostDiscussionData>>;
 }
 

--- a/spec/daily-changelog.md
+++ b/spec/daily-changelog.md
@@ -159,7 +159,7 @@
 1. **プロバイダーラベル**: データが存在するプロバイダーのラベルを付与
    - `GitHub Changelog`, `AWS`, `Claude Code`, `Linear`
 
-2. **サブカテゴリラベル**（日次のみ）:
+2. **サブカテゴリラベル**:
    - GitHub: `gh:copilot`, `gh:actions`, `gh:security` など
    - AWS: `aws:s3`, `aws:lambda`, `aws:ec2` など
 

--- a/spec/weekly-changelog.md
+++ b/spec/weekly-changelog.md
@@ -61,6 +61,17 @@
 2. **今週のハイライト**: 3-5行の箇条書きでプロバイダー全体の重要な変更点をまとめる
 3. **カテゴリ別詳細**（GitHub/AWS）またはリリース一覧（Claude Code/Linear）
 
+### Discussionラベル
+
+各Discussionには以下のラベルが自動付与されます：
+
+1. **プロバイダーラベル**: `GitHub Changelog`, `AWS`, `Claude Code`, `Linear`
+2. **サブカテゴリラベル**: 元データの`labels`フィールドから抽出
+   - GitHub: `gh:copilot`, `gh:actions`, `gh:security` など
+   - AWS: `aws:s3`, `aws:lambda`, `aws:ec2` など
+
+ラベル生成ルールは日次と同じです（`spec/daily-changelog.md` 参照）。
+
 ---
 
 ## 4. カテゴリ分類ルール


### PR DESCRIPTION
週次Discussionのラベル生成を、Claude生成のカテゴリ名ではなく
元データのlabelsフィールドから抽出するように変更。

変更内容:
- postDiscussionメソッドにproviderDataパラメータを追加
- summaryパラメータを削除（未使用のため）
- buildSingleProviderChangelogDataをbuildChangelogDataFromProviderDataに変更
- ラベル抽出を元データから直接行うように修正

Before: aws:AI/ML (Bedrock/SageMaker)（Claude生成カテゴリ名）
After: aws:deadline-cloud, aws:rds（元データのlabels）