### PR TITLE
feat: DiscussionカテゴリをGitHub Issueで管理可能に

### DIFF
--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.login-gh-app-fetch.outputs.token }}
           MUTE_WORDS_ISSUE_NUMBER: "1"
+          CATEGORY_CONFIG_ISSUE_NUMBER: "104"
         run: |
           if [ -n "${{ inputs.date }}" ]; then
             TARGET_DATE="${{ inputs.date }}"
@@ -111,6 +112,8 @@ jobs:
         if: steps.fetch.outputs.has_changelog == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.login-gh-app.outputs.token }}
+          CATEGORY_CONFIG_ISSUE_NUMBER: "104"
+          WORKFLOW_TRIGGER: ${{ github.event_name }}
         run: |
           # Claude Code の structured_output をファイルに書き出し
           cat <<'EOF' > /tmp/changelog-summaries.json
@@ -119,13 +122,13 @@ jobs:
 
           TRIMMED_CONTENT="$(tr -d '[:space:]' < /tmp/changelog-summaries.json)"
 
-          DISCUSSION_CATEGORY="${{ github.event_name == 'workflow_dispatch' && 'manual trigger' || 'Daily' }}"
+          # カテゴリはスクリプト内で環境変数から取得
           if [ -s /tmp/changelog-summaries.json ] && [ "$TRIMMED_CONTENT" != "null" ] && [ -n "$TRIMMED_CONTENT" ]; then
             echo "Using changelog summaries from file"
-            deno task post --category=changelog --date=${{ steps.fetch.outputs.target_date }} --summaries-file=/tmp/changelog-summaries.json korosuke613 mynewshq "$DISCUSSION_CATEGORY"
+            deno task post --category=changelog --date=${{ steps.fetch.outputs.target_date }} --summaries-file=/tmp/changelog-summaries.json korosuke613 mynewshq
           else
             echo "Warning: No valid changelog summaries JSON from Claude Code, using default body"
-            deno task post --category=changelog --date=${{ steps.fetch.outputs.target_date }} korosuke613 mynewshq "$DISCUSSION_CATEGORY"
+            deno task post --category=changelog --date=${{ steps.fetch.outputs.target_date }} korosuke613 mynewshq
           fi
 
       # ========================================
@@ -161,6 +164,8 @@ jobs:
         if: steps.fetch.outputs.has_blog == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.login-gh-app.outputs.token }}
+          CATEGORY_CONFIG_ISSUE_NUMBER: "104"
+          WORKFLOW_TRIGGER: ${{ github.event_name }}
         run: |
           # Claude Code の structured_output をファイルに書き出し
           cat <<'EOF' > /tmp/blog-summaries.json
@@ -169,11 +174,11 @@ jobs:
 
           TRIMMED_CONTENT="$(tr -d '[:space:]' < /tmp/blog-summaries.json)"
 
-          DISCUSSION_CATEGORY="${{ github.event_name == 'workflow_dispatch' && 'manual trigger' || 'Daily' }}"
+          # カテゴリはスクリプト内で環境変数から取得
           if [ -s /tmp/blog-summaries.json ] && [ "$TRIMMED_CONTENT" != "null" ] && [ -n "$TRIMMED_CONTENT" ]; then
             echo "Using blog summaries from file"
-            deno task post --category=blog --date=${{ steps.fetch.outputs.target_date }} --summaries-file=/tmp/blog-summaries.json korosuke613 mynewshq "$DISCUSSION_CATEGORY"
+            deno task post --category=blog --date=${{ steps.fetch.outputs.target_date }} --summaries-file=/tmp/blog-summaries.json korosuke613 mynewshq
           else
             echo "Warning: No valid blog summaries JSON from Claude Code, using default body"
-            deno task post --category=blog --date=${{ steps.fetch.outputs.target_date }} korosuke613 mynewshq "$DISCUSSION_CATEGORY"
+            deno task post --category=blog --date=${{ steps.fetch.outputs.target_date }} korosuke613 mynewshq
           fi

--- a/.github/workflows/weekly-changelog.yml
+++ b/.github/workflows/weekly-changelog.yml
@@ -86,6 +86,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.login-gh-app.outputs.token }}
           MUTE_WORDS_ISSUE_NUMBER: "1"
+          CATEGORY_CONFIG_ISSUE_NUMBER: "104"
         run: |
           deno task fetch --days=7 --weekly --date=${{ steps.target-date.outputs.end_date }}
 
@@ -299,6 +300,8 @@ jobs:
       - name: Merge summaries and post discussions
         env:
           GITHUB_TOKEN: ${{ steps.login-gh-app.outputs.token }}
+          CATEGORY_CONFIG_ISSUE_NUMBER: "104"
+          WORKFLOW_TRIGGER: ${{ github.event_name }}
         run: |
           # 要約ファイルを統合
           echo "Merging summaries..."
@@ -336,10 +339,9 @@ jobs:
             AUTO_CLOSE_FLAG="--auto-close"
           fi
 
-          # Discussion投稿
+          # Discussion投稿（カテゴリはスクリプト内で環境変数から取得）
           deno task post-weekly-all \
             --date=${{ needs.fetch-data.outputs.end_date }} \
             --changelog-file=data/changelogs/weekly/${{ needs.fetch-data.outputs.end_date }}.json \
             --summaries-file=/tmp/all-summaries.json \
-            --category="${{ github.event_name == 'workflow_dispatch' && 'manual trigger' || 'Weekly' }}" \
             $AUTO_CLOSE_FLAG

--- a/plans/2026-01-28-discussion-category-issue-management.md
+++ b/plans/2026-01-28-discussion-category-issue-management.md
@@ -1,0 +1,201 @@
+# DiscussionカテゴリのIssue管理機能
+
+## 概要
+
+Discussionの投稿先カテゴリ名をGitHub Issueで管理できるようにする。
+ミュートワード機能（Issue #1）と同様のパターンで実装。
+
+## 現状
+
+### カテゴリ名のハードコード箇所
+
+| ファイル | 行 | 値 |
+|---------|----|----|
+| `.github/workflows/daily-changelog.yml` | 122, 172 | `Daily` / `manual trigger` |
+| `scripts/create-discussion.ts` | 982 | `General` |
+| `scripts/weekly-orchestrator.ts` | 52 | `General` |
+| `scripts/post-weekly-provider.ts` | 58 | `Weekly` |
+
+### 現在の動作
+**Changelog:**
+- 日次スケジュール → `Daily` カテゴリ
+- 日次手動実行 → `manual trigger` カテゴリ
+- 週次スケジュール → `Weekly` カテゴリ
+- 週次手動実行 → `manual trigger` カテゴリ
+
+**Blog:**
+- 日次スケジュール → `Daily` カテゴリ
+- 日次手動実行 → `manual trigger` カテゴリ
+
+**デフォルト:** `General` カテゴリ
+
+## 実装計画
+
+### Issue本文フォーマット（Issue #2 想定）
+
+```markdown
+# Discussion カテゴリ設定
+
+## Changelog カテゴリ
+- changelog_daily: Daily
+- changelog_weekly: Weekly
+- changelog_manual: manual trigger
+
+## Blog カテゴリ
+- blog_daily: Daily
+- blog_manual: manual trigger
+
+## デフォルト
+- default: General
+```
+
+※ `*_manual` は手動実行時に使用
+
+### Step 1: パーサー関数の追加
+
+**ファイル**: `scripts/domain/category-config.ts`（新規）
+
+```typescript
+export interface CategoryConfig {
+  // Changelog用
+  changelogDaily: string;
+  changelogWeekly: string;
+  changelogManual: string;
+  // Blog用
+  blogDaily: string;
+  blogManual: string;
+  // 共通デフォルト
+  default: string;
+}
+
+export const DEFAULT_CATEGORY_CONFIG: CategoryConfig = {
+  changelogDaily: "Daily",
+  changelogWeekly: "Weekly",
+  changelogManual: "manual trigger",
+  blogDaily: "Daily",
+  blogManual: "manual trigger",
+  default: "General",
+};
+
+export function parseCategoryConfig(issueBody: string): CategoryConfig {
+  const config = { ...DEFAULT_CATEGORY_CONFIG };
+  const lines = issueBody.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("- ")) {
+      const match = trimmed.match(/^- ([\w_]+): (.+)$/);
+      if (match) {
+        const [, key, value] = match;
+        switch (key) {
+          case "changelog_daily": config.changelogDaily = value.trim(); break;
+          case "changelog_weekly": config.changelogWeekly = value.trim(); break;
+          case "changelog_manual": config.changelogManual = value.trim(); break;
+          case "blog_daily": config.blogDaily = value.trim(); break;
+          case "blog_manual": config.blogManual = value.trim(); break;
+          case "default": config.default = value.trim(); break;
+        }
+      }
+    }
+  }
+  return config;
+}
+
+// カテゴリタイプとトリガーに基づいてカテゴリ名を取得
+export function getCategoryName(
+  config: CategoryConfig,
+  categoryType: "changelog" | "blog",
+  trigger: "schedule" | "workflow_dispatch",
+  isWeekly: boolean = false,
+): string {
+  if (trigger === "workflow_dispatch") {
+    return categoryType === "blog" ? config.blogManual : config.changelogManual;
+  }
+
+  if (categoryType === "blog") {
+    return config.blogDaily;
+  }
+
+  return isWeekly ? config.changelogWeekly : config.changelogDaily;
+}
+```
+
+### Step 2: Issueから設定を取得する関数
+
+**ファイル**: `scripts/domain/category-config.ts`（続き）
+
+```typescript
+export async function fetchCategoryConfig(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<CategoryConfig> {
+  try {
+    const { data: issue } = await octokit.issues.get({
+      owner,
+      repo,
+      issue_number: issueNumber,
+    });
+
+    if (!issue.body) {
+      console.warn(`Issue #${issueNumber} has no body, using defaults`);
+      return DEFAULT_CATEGORY_CONFIG;
+    }
+
+    const config = parseCategoryConfig(issue.body);
+    console.log(`Loaded category config from issue #${issueNumber}`);
+    return config;
+  } catch (error) {
+    console.warn(`Failed to fetch category config: ${error}`);
+    return DEFAULT_CATEGORY_CONFIG;
+  }
+}
+```
+
+### Step 3: ワークフローの更新
+
+**ファイル**: `.github/workflows/daily-changelog.yml`
+
+```yaml
+env:
+  CATEGORY_CONFIG_ISSUE_NUMBER: "2"
+
+# 投稿時
+- name: Post Changelog
+  env:
+    CATEGORY_CONFIG_ISSUE_NUMBER: ${{ env.CATEGORY_CONFIG_ISSUE_NUMBER }}
+    WORKFLOW_TRIGGER: ${{ github.event_name }}
+  run: |
+    deno task post --category=changelog ...
+```
+
+### Step 4: 投稿スクリプトの更新
+
+**ファイル**: `scripts/create-discussion.ts`
+
+- `fetchCategoryConfig()` を呼び出し
+- `WORKFLOW_TRIGGER` 環境変数と `--category` 引数（changelog/blog）に応じてカテゴリを選択
+- `getCategoryName()` ヘルパー関数を使用
+
+### 修正対象ファイル
+
+1. `scripts/domain/category-config.ts` - 新規作成
+2. `scripts/domain/category-config_test.ts` - テスト
+3. `scripts/create-discussion.ts` - 設定読み込み追加
+4. `scripts/weekly-orchestrator.ts` - 設定読み込み追加
+5. `scripts/post-weekly-provider.ts` - 設定読み込み追加
+6. `.github/workflows/daily-changelog.yml` - 環境変数追加
+7. `.github/workflows/weekly-changelog.yml` - 環境変数追加
+
+## 検証方法
+
+1. Issue #2 を作成してカテゴリ設定を記述
+2. `deno task test` でテスト実行
+3. ローカルでプレビュー実行して設定が読み込まれることを確認
+4. 手動ワークフロー実行でDiscussionが正しいカテゴリに投稿されることを確認
+
+## 備考
+
+- Issue取得失敗時はデフォルト値にフォールバック
+- ミュートワードと同様、ワークフロー実行ごとにIssueを取得

--- a/scripts/domain/category-config.ts
+++ b/scripts/domain/category-config.ts
@@ -1,0 +1,221 @@
+// Discussionカテゴリ設定の管理
+// Issue本文からカテゴリ設定を読み取り、トリガーとカテゴリタイプに応じてカテゴリ名を返す
+
+import { Octokit } from "@octokit/rest";
+
+/**
+ * Discussionカテゴリ設定
+ */
+export interface CategoryConfig {
+  // Changelog用
+  changelogDaily: string;
+  changelogWeekly: string;
+  changelogManual: string;
+  // Blog用
+  blogDaily: string;
+  blogManual: string;
+  // 共通デフォルト
+  default: string;
+}
+
+/**
+ * デフォルトのカテゴリ設定
+ */
+export const DEFAULT_CATEGORY_CONFIG: CategoryConfig = {
+  changelogDaily: "Daily",
+  changelogWeekly: "Weekly",
+  changelogManual: "manual trigger",
+  blogDaily: "Daily",
+  blogManual: "manual trigger",
+  default: "General",
+};
+
+/**
+ * Issue本文からカテゴリ設定をパースする
+ *
+ * 期待されるフォーマット:
+ * ```markdown
+ * # Discussion カテゴリ設定
+ *
+ * ## Changelog カテゴリ
+ * - changelog_daily: Daily
+ * - changelog_weekly: Weekly
+ * - changelog_manual: manual trigger
+ *
+ * ## Blog カテゴリ
+ * - blog_daily: Daily
+ * - blog_manual: manual trigger
+ *
+ * ## デフォルト
+ * - default: General
+ * ```
+ */
+export function parseCategoryConfig(issueBody: string): CategoryConfig {
+  const config = { ...DEFAULT_CATEGORY_CONFIG };
+  const lines = issueBody.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("- ")) {
+      const match = trimmed.match(/^- ([\w_]+): (.+)$/);
+      if (match) {
+        const [, key, value] = match;
+        const trimmedValue = value.trim();
+        switch (key) {
+          case "changelog_daily":
+            config.changelogDaily = trimmedValue;
+            break;
+          case "changelog_weekly":
+            config.changelogWeekly = trimmedValue;
+            break;
+          case "changelog_manual":
+            config.changelogManual = trimmedValue;
+            break;
+          case "blog_daily":
+            config.blogDaily = trimmedValue;
+            break;
+          case "blog_manual":
+            config.blogManual = trimmedValue;
+            break;
+          case "default":
+            config.default = trimmedValue;
+            break;
+        }
+      }
+    }
+  }
+
+  return config;
+}
+
+/**
+ * カテゴリタイプ
+ */
+export type CategoryType = "changelog" | "blog";
+
+/**
+ * ワークフロートリガータイプ
+ */
+export type WorkflowTrigger = "schedule" | "workflow_dispatch";
+
+/**
+ * カテゴリタイプとトリガーに基づいてカテゴリ名を取得する
+ *
+ * @param config カテゴリ設定
+ * @param categoryType "changelog" または "blog"
+ * @param trigger "schedule" または "workflow_dispatch"
+ * @param isWeekly 週次処理かどうか（changelogのみ影響）
+ * @returns カテゴリ名
+ */
+export function getCategoryName(
+  config: CategoryConfig,
+  categoryType: CategoryType,
+  trigger: WorkflowTrigger,
+  isWeekly: boolean = false,
+): string {
+  // 手動実行の場合
+  if (trigger === "workflow_dispatch") {
+    return categoryType === "blog" ? config.blogManual : config.changelogManual;
+  }
+
+  // スケジュール実行の場合
+  if (categoryType === "blog") {
+    return config.blogDaily;
+  }
+
+  // Changelog: 週次か日次かで分岐
+  return isWeekly ? config.changelogWeekly : config.changelogDaily;
+}
+
+/**
+ * GitHubのIssueからカテゴリ設定を取得する
+ *
+ * @param octokit Octokit インスタンス
+ * @param owner リポジトリオーナー
+ * @param repo リポジトリ名
+ * @param issueNumber Issue番号
+ * @returns カテゴリ設定（取得失敗時はデフォルト値）
+ */
+export async function fetchCategoryConfig(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<CategoryConfig> {
+  try {
+    const { data: issue } = await octokit.issues.get({
+      owner,
+      repo,
+      issue_number: issueNumber,
+    });
+
+    if (!issue.body) {
+      console.warn(`Issue #${issueNumber} has no body, using defaults`);
+      return DEFAULT_CATEGORY_CONFIG;
+    }
+
+    const config = parseCategoryConfig(issue.body);
+    console.log(`Loaded category config from issue #${issueNumber}`);
+    return config;
+  } catch (error) {
+    console.warn(`Failed to fetch category config: ${error}`);
+    return DEFAULT_CATEGORY_CONFIG;
+  }
+}
+
+/**
+ * 環境変数から設定を読み込み、カテゴリ名を取得するヘルパー関数
+ *
+ * @param octokit Octokit インスタンス
+ * @param owner リポジトリオーナー
+ * @param repo リポジトリ名
+ * @param categoryType "changelog" または "blog"
+ * @param isWeekly 週次処理かどうか
+ * @returns カテゴリ名
+ */
+export async function getCategoryNameFromEnv(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  categoryType: CategoryType,
+  isWeekly: boolean = false,
+): Promise<string> {
+  // 環境変数からIssue番号を取得
+  const issueNumberStr = Deno.env.get("CATEGORY_CONFIG_ISSUE_NUMBER");
+
+  // 環境変数からワークフロートリガーを取得
+  const triggerStr = Deno.env.get("WORKFLOW_TRIGGER");
+  const trigger: WorkflowTrigger = triggerStr === "workflow_dispatch"
+    ? "workflow_dispatch"
+    : "schedule";
+
+  // Issue番号が設定されていない場合はデフォルト設定を使用
+  if (!issueNumberStr) {
+    console.log(
+      "CATEGORY_CONFIG_ISSUE_NUMBER not set, using default category config",
+    );
+    return getCategoryName(
+      DEFAULT_CATEGORY_CONFIG,
+      categoryType,
+      trigger,
+      isWeekly,
+    );
+  }
+
+  const issueNumber = parseInt(issueNumberStr, 10);
+  if (isNaN(issueNumber)) {
+    console.warn(
+      `Invalid CATEGORY_CONFIG_ISSUE_NUMBER: ${issueNumberStr}, using defaults`,
+    );
+    return getCategoryName(
+      DEFAULT_CATEGORY_CONFIG,
+      categoryType,
+      trigger,
+      isWeekly,
+    );
+  }
+
+  // Issueから設定を取得
+  const config = await fetchCategoryConfig(octokit, owner, repo, issueNumber);
+  return getCategoryName(config, categoryType, trigger, isWeekly);
+}

--- a/scripts/domain/category-config_test.ts
+++ b/scripts/domain/category-config_test.ts
@@ -1,0 +1,151 @@
+import { assertEquals } from "@std/assert";
+import {
+  DEFAULT_CATEGORY_CONFIG,
+  getCategoryName,
+  parseCategoryConfig,
+} from "./category-config.ts";
+
+Deno.test("parseCategoryConfig", async (t) => {
+  await t.step("全てのカテゴリを正しくパースする", () => {
+    const issueBody = `# Discussion カテゴリ設定
+
+## Changelog カテゴリ
+- changelog_daily: Daily
+- changelog_weekly: Weekly
+- changelog_manual: manual trigger
+
+## Blog カテゴリ
+- blog_daily: Daily
+- blog_manual: manual trigger
+
+## デフォルト
+- default: General`;
+
+    const result = parseCategoryConfig(issueBody);
+    assertEquals(result.changelogDaily, "Daily");
+    assertEquals(result.changelogWeekly, "Weekly");
+    assertEquals(result.changelogManual, "manual trigger");
+    assertEquals(result.blogDaily, "Daily");
+    assertEquals(result.blogManual, "manual trigger");
+    assertEquals(result.default, "General");
+  });
+
+  await t.step(
+    "一部のカテゴリのみ設定された場合、未設定はデフォルト値を使用",
+    () => {
+      const issueBody = `# カテゴリ設定
+
+- changelog_daily: Custom Daily
+- blog_manual: Custom Manual`;
+
+      const result = parseCategoryConfig(issueBody);
+      assertEquals(result.changelogDaily, "Custom Daily");
+      assertEquals(result.changelogWeekly, "Weekly"); // デフォルト
+      assertEquals(result.changelogManual, "manual trigger"); // デフォルト
+      assertEquals(result.blogDaily, "Daily"); // デフォルト
+      assertEquals(result.blogManual, "Custom Manual");
+      assertEquals(result.default, "General"); // デフォルト
+    },
+  );
+
+  await t.step("空のIssue本文の場合はデフォルト値を返す", () => {
+    const result = parseCategoryConfig("");
+    assertEquals(result, DEFAULT_CATEGORY_CONFIG);
+  });
+
+  await t.step("箇条書きがない場合はデフォルト値を返す", () => {
+    const issueBody = "これは普通のテキストです。カテゴリ設定はありません。";
+    const result = parseCategoryConfig(issueBody);
+    assertEquals(result, DEFAULT_CATEGORY_CONFIG);
+  });
+
+  await t.step("値の前後の空白をトリムする", () => {
+    const issueBody = `- changelog_daily:   Custom Category   `;
+    const result = parseCategoryConfig(issueBody);
+    assertEquals(result.changelogDaily, "Custom Category");
+  });
+
+  await t.step("未知のキーは無視する", () => {
+    const issueBody = `- changelog_daily: Daily
+- unknown_key: Some Value
+- another_unknown: Another Value`;
+
+    const result = parseCategoryConfig(issueBody);
+    assertEquals(result.changelogDaily, "Daily");
+    // 他の値はデフォルト
+    assertEquals(result.changelogWeekly, "Weekly");
+  });
+});
+
+Deno.test("getCategoryName", async (t) => {
+  const config = {
+    changelogDaily: "Test Daily",
+    changelogWeekly: "Test Weekly",
+    changelogManual: "Test Manual",
+    blogDaily: "Blog Daily",
+    blogManual: "Blog Manual",
+    default: "Test General",
+  };
+
+  await t.step("changelog + schedule + 日次 → changelogDaily", () => {
+    const result = getCategoryName(config, "changelog", "schedule", false);
+    assertEquals(result, "Test Daily");
+  });
+
+  await t.step("changelog + schedule + 週次 → changelogWeekly", () => {
+    const result = getCategoryName(config, "changelog", "schedule", true);
+    assertEquals(result, "Test Weekly");
+  });
+
+  await t.step("changelog + workflow_dispatch → changelogManual", () => {
+    const result = getCategoryName(
+      config,
+      "changelog",
+      "workflow_dispatch",
+      false,
+    );
+    assertEquals(result, "Test Manual");
+  });
+
+  await t.step(
+    "changelog + workflow_dispatch + 週次 → changelogManual（isWeeklyは無視）",
+    () => {
+      const result = getCategoryName(
+        config,
+        "changelog",
+        "workflow_dispatch",
+        true,
+      );
+      assertEquals(result, "Test Manual");
+    },
+  );
+
+  await t.step("blog + schedule → blogDaily", () => {
+    const result = getCategoryName(config, "blog", "schedule", false);
+    assertEquals(result, "Blog Daily");
+  });
+
+  await t.step("blog + workflow_dispatch → blogManual", () => {
+    const result = getCategoryName(config, "blog", "workflow_dispatch", false);
+    assertEquals(result, "Blog Manual");
+  });
+
+  await t.step(
+    "blog + schedule + isWeekly=true でも blogDaily（blogには週次がない）",
+    () => {
+      const result = getCategoryName(config, "blog", "schedule", true);
+      assertEquals(result, "Blog Daily");
+    },
+  );
+});
+
+Deno.test("DEFAULT_CATEGORY_CONFIG", async (t) => {
+  await t.step("デフォルト値が正しく設定されている", () => {
+    assertEquals(DEFAULT_CATEGORY_CONFIG.changelogDaily, "Daily");
+    assertEquals(DEFAULT_CATEGORY_CONFIG.changelogWeekly, "Weekly");
+    assertEquals(DEFAULT_CATEGORY_CONFIG.changelogManual, "manual trigger");
+    assertEquals(DEFAULT_CATEGORY_CONFIG.blogDaily, "Daily");
+    assertEquals(DEFAULT_CATEGORY_CONFIG.blogManual, "manual trigger");
+    assertEquals(DEFAULT_CATEGORY_CONFIG.default, "General");
+  });
+});


### PR DESCRIPTION
Issue #2 からカテゴリ設定を読み込み、ワークフロートリガー
（schedule/workflow_dispatch）とカテゴリタイプ（changelog/blog）に 応じて適切なDiscussionカテゴリを自動選択する機能を追加。

- scripts/domain/category-config.ts: カテゴリ設定パーサーとヘルパー関数
- 環境変数 CATEGORY_CONFIG_ISSUE_NUMBER, WORKFLOW_TRIGGER に対応
- Issue取得失敗時はデフォルト値にフォールバック