### PR TITLE
chore: install_deps.shでdenoコマンドを絶対パスで実行

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,7 +29,8 @@
   "plansDirectory": "./plans",
   "enabledPlugins": {
     "dev-standards@korosuke613": true,
-    "github@korosuke613": true
+    "github@korosuke613": true,
+    "git@korosuke613": true
   },
   "permissions": {
     "allow": [

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -22,7 +22,7 @@ fi
 
 # deno.jsonが存在する場合のみ依存関係をキャッシュ
 if [ -f "$CLAUDE_PROJECT_DIR/deno.json" ]; then
-  deno cache "$CLAUDE_PROJECT_DIR/deno.json"
+  "$DENO_INSTALL/bin/deno" cache "$CLAUDE_PROJECT_DIR/deno.json"
 fi
 
 exit 0


### PR DESCRIPTION
Denoインストール直後にPATHが反映されない問題を修正。
deno cacheコマンドを$DENO_INSTALL/bin/denoの絶対パスで実行することで、 環境変数の読み込みタイミングに依存しない確実な実行を保証。