### PR TITLE
ci: schedule トリガーを gh-cron-trigger アノテーションに移行

### DIFF
--- a/.github/workflows/daily-changelog-and-blog.yaml
+++ b/.github/workflows/daily-changelog-and-blog.yaml
@@ -1,10 +1,9 @@
 name: Daily Changelog and Blog
 
 on:
-  schedule:
-    # 毎日 10:50 JST (UTC 1:50) = PST 17:50 / PDT 18:50
-    # アメリカ西海岸時間の夜（18:00くらい）の更新をカバー
-    - cron: 50 1 * * *
+  # 毎日 11:59 JST (UTC 2:59) = PST 18:59 / PDT 19:59
+  # アメリカ西海岸時間の夜（18:00くらい）の更新をカバー
+  # gh-cron-trigger: "59 11 * * *"
   workflow_dispatch: # 手動実行も可能
     inputs:
       date:

--- a/.github/workflows/weekly-blog.yml
+++ b/.github/workflows/weekly-blog.yml
@@ -1,9 +1,8 @@
 name: Weekly Blog
 
 on:
-  schedule:
-    # 毎週水曜日 01:00 UTC (10:00 JST)
-    - cron: "0 1 * * 3"
+  # 毎週水曜日 01:00 UTC (10:00 JST)
+  # gh-cron-trigger: "0 10 * * 3"
   workflow_dispatch:
     inputs:
       end_date:

--- a/.github/workflows/weekly-changelog.yml
+++ b/.github/workflows/weekly-changelog.yml
@@ -1,9 +1,8 @@
 name: Weekly Changelog
 
 on:
-  schedule:
-    # 毎週水曜日 01:00 UTC (10:00 JST)
-    - cron: "0 1 * * 3"
+  # 毎週水曜日 01:00 UTC (10:00 JST)
+  # gh-cron-trigger: "0 10 * * 3"
   workflow_dispatch:
     inputs:
       end_date:


### PR DESCRIPTION
GitHub Actions schedule の最大1時間超の遅延問題を回避するため、
ネイティブ schedule を削除し gh-cron-trigger による workflow_dispatch 方式に切り替え。cron 式は JST 表記に統一。