### PR TITLE
ci: gh-cron-triggerからghacronへ移行しTZサポートを追加

### DIFF
--- a/.github/workflows/daily-changelog-and-blog.yaml
+++ b/.github/workflows/daily-changelog-and-blog.yaml
@@ -3,7 +3,7 @@ name: Daily Changelog and Blog
 on:
   # 毎日 11:59 JST (UTC 2:59) = PST 18:59 / PDT 19:59
   # アメリカ西海岸時間の夜（18:00くらい）の更新をカバー
-  # gh-cron-trigger: "59 11 * * *"
+  # ghacron: "TZ=Asia/Tokyo 59 11 * * *"
   workflow_dispatch: # 手動実行も可能
     inputs:
       date:
@@ -133,7 +133,7 @@ jobs:
         with:
           github_token: ${{ steps.login-gh-app.outputs.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "kiba-gh-cron-trigger"
+          allowed_bots: "kiba-ghacron"
           claude_args: >-
             --json-schema '{"type":"object","properties":{"github":{"type":"object","additionalProperties":{"type":"string"}},"aws":{"type":"object","additionalProperties":{"type":"string"}},"claudeCode":{"type":"object","additionalProperties":{"type":"string"}},"githubCli":{"type":"object","additionalProperties":{"type":"string"}},"linear":{"type":"object","additionalProperties":{"type":"string"}}},"required":["github","aws","claudeCode","githubCli","linear"]}'
           prompt: |
@@ -183,7 +183,7 @@ jobs:
         with:
           github_token: ${{ steps.login-gh-app.outputs.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "kiba-gh-cron-trigger"
+          allowed_bots: "kiba-ghacron"
           claude_args: >-
             --json-schema '{"type":"object","properties":{"hatenaBookmark":{"type":"object","properties":{"categories":{"type":"array","items":{"type":"object","properties":{"category":{"type":"string"},"entries":{"type":"array","items":{"type":"object","properties":{"url":{"type":"string"},"title":{"type":"string"},"comment":{"type":"string"}},"required":["url","title","comment"]}},"categoryComment":{"type":"string"}},"required":["category","entries","categoryComment"]}}},"required":["categories"]}},"required":["hatenaBookmark"]}'
           prompt: |

--- a/.github/workflows/generate-feed.yml
+++ b/.github/workflows/generate-feed.yml
@@ -2,7 +2,7 @@ name: Generate Feed
 
 on:
   # 3時間に1回
-  # gh-cron-trigger: "0 */3 * * *"
+  # ghacron: "TZ=Asia/Tokyo 0 */3 * * *"
   discussion:
     types: [created, edited]
   workflow_dispatch:

--- a/.github/workflows/weekly-blog.yml
+++ b/.github/workflows/weekly-blog.yml
@@ -2,7 +2,7 @@ name: Weekly Blog
 
 on:
   # 毎週水曜日 01:00 UTC (10:00 JST)
-  # gh-cron-trigger: "0 10 * * 3"
+  # ghacron: "TZ=Asia/Tokyo 0 10 * * 3"
   workflow_dispatch:
     inputs:
       end_date:
@@ -135,7 +135,7 @@ jobs:
         with:
           github_token: ${{ steps.login-gh-app.outputs.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "kiba-gh-cron-trigger"
+          allowed_bots: "kiba-ghacron"
           claude_args: >-
             --json-schema '{"type":"object","properties":{"hatenaBookmark":{"type":"object","properties":{"highlights":{"type":"array","items":{"type":"string"}},"categories":{"type":"array","items":{"type":"object","properties":{"category":{"type":"string"},"entries":{"type":"array","items":{"type":"object","properties":{"url":{"type":"string"},"title":{"type":"string"},"comment":{"type":"string"}},"required":["url","title","comment"]}},"categoryComment":{"type":"string"}},"required":["category","entries","categoryComment"]}}},"required":["highlights","categories"]}},"required":["hatenaBookmark"]}'
           prompt: |

--- a/.github/workflows/weekly-changelog.yml
+++ b/.github/workflows/weekly-changelog.yml
@@ -2,7 +2,7 @@ name: Weekly Changelog
 
 on:
   # 毎週水曜日 01:00 UTC (10:00 JST)
-  # gh-cron-trigger: "0 10 * * 3"
+  # ghacron: "TZ=Asia/Tokyo 0 10 * * 3"
   workflow_dispatch:
     inputs:
       end_date:
@@ -201,7 +201,7 @@ jobs:
         with:
           github_token: ${{ steps.login-gh-app.outputs.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "kiba-gh-cron-trigger"
+          allowed_bots: "kiba-ghacron"
           claude_args: >-
             --json-schema '${{ matrix.json_schema }}'
           prompt: |


### PR DESCRIPTION
全ワークフローのcronコメント構文をghacron形式に更新し、
TZ=Asia/Tokyoによる明示的なタイムゾーン指定を導入。
allowed_botsもkiba-ghacronに統一。